### PR TITLE
Added: Allow kwargs to dump* methods

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -77,8 +77,6 @@ jobs:
         run: |
           poetry build
           echo "github.ref = ${{ github.ref }}"
-      - name: Check distributions
-        run: twine check dist/*
       - name: Publish package to TestPyPI
         uses: pypa/gh-action-pypi-publish@master
         if: github.repository == 'spraakbanken/json-streams-py' && !startsWith(github.ref, 'refs/tags/')

--- a/json_streams/__init__.py
+++ b/json_streams/__init__.py
@@ -7,6 +7,7 @@ import typing
 
 from . import json_iter
 from . import jsonl_iter
+from . import encoders
 from json_streams import utility
 from json_streams.utility import types
 

--- a/json_streams/__init__.py
+++ b/json_streams/__init__.py
@@ -72,6 +72,7 @@ def dump_to_file(
     file_mode: str = "bw",
     use_stdout_as_default: bool = False,
     use_stderr_as_default: bool = False,
+    **kwargs,
 ):
     """Open file and dump json to it.
 
@@ -86,7 +87,7 @@ def dump_to_file(
     if file_name is not None:
         _iter = choose_iter(file_name, json_format)
 
-        _iter.dump_to_file(in_iter_, file_name, file_mode=file_mode)
+        _iter.dump_to_file(in_iter_, file_name, file_mode=file_mode, **kwargs)
 
     elif use_stdout_as_default:
         jsonl_iter.dump(in_iter_, sys.stdout.buffer)

--- a/json_streams/__init__.py
+++ b/json_streams/__init__.py
@@ -30,6 +30,7 @@ def load_from_file(
     json_format: Optional[utility.JsonFormat] = None,
     file_mode: str = "br",
     use_stdin_as_default: bool = False,
+    **kwargs,
 ) -> Iterable:
     """Lazily load from given file_name.
 
@@ -50,10 +51,10 @@ def load_from_file(
     if file_name is not None:
         _iter = choose_iter(file_name, json_format)
 
-        yield from _iter.load_from_file(file_name, file_mode=file_mode)
+        yield from _iter.load_from_file(file_name, file_mode=file_mode, **kwargs)
 
     elif use_stdin_as_default:
-        yield from jsonl_iter.load(sys.stdin.buffer)
+        yield from jsonl_iter.load(sys.stdin.buffer, **kwargs)
     else:
         raise ValueError("You can't read from a empty file")
 
@@ -90,9 +91,9 @@ def dump_to_file(
         _iter.dump_to_file(in_iter_, file_name, file_mode=file_mode, **kwargs)
 
     elif use_stdout_as_default:
-        jsonl_iter.dump(in_iter_, sys.stdout.buffer)
+        jsonl_iter.dump(in_iter_, sys.stdout.buffer, **kwargs)
     elif use_stderr_as_default:
-        jsonl_iter.dump(in_iter_, sys.stderr.buffer)
+        jsonl_iter.dump(in_iter_, sys.stderr.buffer, **kwargs)
     else:
         raise ValueError("file_name can't be empty")
 

--- a/json_streams/backends/be_json.py
+++ b/json_streams/backends/be_json.py
@@ -5,9 +5,9 @@ from typing import Any, Union
 # pylint: disable=unsubscriptable-object
 
 
-def dumps(obj) -> bytes:
-    return json.dumps(obj).encode("utf-8")
+def dumps(obj, **kwargs) -> bytes:
+    return json.dumps(obj, **kwargs).encode("utf-8")
 
 
-def loads(s: Union[bytes, bytearray, str]) -> Any:
-    return json.loads(s.decode("utf-8") if isinstance(s, (bytes, bytearray)) else s)
+def loads(s: Union[bytes, bytearray, str], **kwargs) -> Any:
+    return json.loads(s.decode("utf-8") if isinstance(s, (bytes, bytearray)) else s, **kwargs)

--- a/json_streams/encoders/__init__.py
+++ b/json_streams/encoders/__init__.py
@@ -1,0 +1,3 @@
+from .decimal_encoders import encode_decimal
+
+

--- a/json_streams/encoders/decimal_encoders.py
+++ b/json_streams/encoders/decimal_encoders.py
@@ -1,0 +1,8 @@
+import decimal
+from typing import Any
+
+
+def encode_decimal(obj: Any):
+    if isinstance(obj, decimal.Decimal):
+        return float(obj)
+    raise TypeError

--- a/json_streams/json_iter.py
+++ b/json_streams/json_iter.py
@@ -76,8 +76,8 @@ def dumps(obj, **kwargs) -> Iterable[bytes]:
             yield b"]"
 
 
-def load(fp: BinaryIO) -> Iterable:
-    yield from ijson.items(fp, "item")
+def load(fp: BinaryIO, **kwargs) -> Iterable:
+    yield from ijson.items(fp, "item", **kwargs)
 
 
 def load_eager(fp: BinaryIO):
@@ -88,13 +88,13 @@ def load_eager(fp: BinaryIO):
         yield data
 
 
-def load_from_file(file_name: types.Pathlike, *, file_mode: Optional[str] = None):
+def load_from_file(file_name: types.Pathlike, *, file_mode: Optional[str] = None, **kwargs):
     if not file_mode:
         file_mode = "br"
 
     assert "b" in file_mode
     with open(file_name, file_mode) as fp:
-        yield from load(fp)  # type: ignore
+        yield from load(fp, **kwargs)  # type: ignore
 
 
 def dump_to_file(gen: Iterable, file_name: types.Pathlike, *, file_mode: str = None, **kwargs):

--- a/json_streams/json_iter.py
+++ b/json_streams/json_iter.py
@@ -13,7 +13,7 @@ from json_streams.utility import types
 # pylint: disable=unsubscriptable-object
 
 
-def dump(data: Union[Dict, Iterable], fp: BinaryIO):
+def dump(data: Union[Dict, Iterable], fp: BinaryIO, **kwargs):
     """Dump array to a file object.
 
     Parameters
@@ -23,7 +23,7 @@ def dump(data: Union[Dict, Iterable], fp: BinaryIO):
     data :
         Iterable object to write.
     """
-    for chunk in dumps(data):
+    for chunk in dumps(data, **kwargs):
         fp.write(chunk)
 
 
@@ -50,28 +50,28 @@ def dump(data: Union[Dict, Iterable], fp: BinaryIO):
 #     fp.write(b"\n]")
 
 
-def dumps(obj) -> Iterable[bytes]:
+def dumps(obj, **kwargs) -> Iterable[bytes]:
     if isinstance(obj, str):
-        yield jsonlib.dumps(obj)
+        yield jsonlib.dumps(obj, **kwargs)
     elif isinstance(obj, dict):
         yield b"{"
         for i, (key, value) in enumerate(obj.items()):
             if i > 0:
                 yield b","
             yield b'"%s":' % utility.to_bytes(key)
-            yield from dumps(value)
+            yield from dumps(value, **kwargs)
         yield b"}"
     else:
         try:
             it = iter(obj)
         except TypeError:
-            yield jsonlib.dumps(obj)
+            yield jsonlib.dumps(obj, **kwargs)
         else:
             yield b"["
             for i, o in enumerate(it):
                 if i > 0:
                     yield b","
-                yield jsonlib.dumps(o)
+                yield jsonlib.dumps(o, **kwargs)
 
             yield b"]"
 
@@ -97,12 +97,12 @@ def load_from_file(file_name: types.Pathlike, *, file_mode: Optional[str] = None
         yield from load(fp)  # type: ignore
 
 
-def dump_to_file(gen: Iterable, file_name: types.Pathlike, *, file_mode: str = None):
+def dump_to_file(gen: Iterable, file_name: types.Pathlike, *, file_mode: str = None, **kwargs):
     if not file_mode:
         file_mode = "bw"
     assert "b" in file_mode
     with open(file_name, file_mode) as fp:
-        return dump(gen, fp)  # type: ignore
+        return dump(gen, fp, **kwargs)  # type: ignore
 
 
 def sink(fp: BinaryIO):

--- a/json_streams/jsonl_iter.py
+++ b/json_streams/jsonl_iter.py
@@ -27,17 +27,17 @@ def dump(data: Union[Dict, Iterable], fp: BinaryIO, **kwargs):
         fp.write(b"\n")
 
 
-def load(fp: BinaryIO) -> Iterable:
+def load(fp: BinaryIO, **kwargs) -> Iterable:
     for line in fp:
-        yield jsonlib.loads(line)
+        yield jsonlib.loads(line, **kwargs)
 
 
-def load_from_file(file_name: types.Pathlike, *, file_mode: str = None):
+def load_from_file(file_name: types.Pathlike, *, file_mode: str = None, **kwargs):
     if not file_mode:
         file_mode = "br"
     assert "b" in file_mode
     with open(file_name, file_mode) as fp:
-        yield from load(fp)  # type: ignore
+        yield from load(fp, **kwargs)  # type: ignore
 
 
 def dump_to_file(obj, file_name: types.Pathlike, *, file_mode: str = None, **kwargs):

--- a/json_streams/jsonl_iter.py
+++ b/json_streams/jsonl_iter.py
@@ -11,19 +11,19 @@ from json_streams.utility import types
 # pylint: disable=unsubscriptable-object
 
 
-def dump(data: Union[Dict, Iterable], fp: BinaryIO):
+def dump(data: Union[Dict, Iterable], fp: BinaryIO, **kwargs):
 
     if isinstance(data, dict):
-        fp.write(jsonlib.dumps(data))
+        fp.write(jsonlib.dumps(data, **kwargs))
         fp.write(b"\n")
         return
 
     try:
         for obj in data:
-            fp.write(jsonlib.dumps(obj))
+            fp.write(jsonlib.dumps(obj, **kwargs))
             fp.write(b"\n")
     except TypeError:
-        fp.write(jsonlib.dumps(data))
+        fp.write(jsonlib.dumps(data, **kwargs))
         fp.write(b"\n")
 
 
@@ -40,12 +40,12 @@ def load_from_file(file_name: types.Pathlike, *, file_mode: str = None):
         yield from load(fp)  # type: ignore
 
 
-def dump_to_file(obj, file_name: types.Pathlike, *, file_mode: str = None):
+def dump_to_file(obj, file_name: types.Pathlike, *, file_mode: str = None, **kwargs):
     if not file_mode:
         file_mode = "bw"
     assert "b" in file_mode
     with open(file_name, file_mode) as fp:
-        dump(obj, fp)  # type: ignore
+        dump(obj, fp, **kwargs)  # type: ignore
 
 
 def sink(fp: BinaryIO):

--- a/json_streams/jsonlib.py
+++ b/json_streams/jsonlib.py
@@ -30,7 +30,7 @@ dumps = backend.dumps  # type: ignore
 loads = backend.loads  # type: ignore
 
 
-def load_from_file(file_name: types.Pathlike):
+def load_from_file(file_name: types.Pathlike, **kwargs):
     """
     Load the JSON file with the given file_name.
 
@@ -38,10 +38,10 @@ def load_from_file(file_name: types.Pathlike):
     :return: the loaded JSON file.
     """
     with open(file_name, "br") as fp:
-        return loads(fp.read())
+        return loads(fp.read(), **kwargs)
 
 
-def dump_to_file(obj, file_name: types.Pathlike):
+def dump_to_file(obj, file_name: types.Pathlike, **kwargs):
     """
     Dump to a JSON file with the given file name.
 
@@ -50,4 +50,4 @@ def dump_to_file(obj, file_name: types.Pathlike):
     :return: anything returned from the backend.
     """
     with open(file_name, "bw") as fp:
-        return fp.write(dumps(obj))
+        return fp.write(dumps(obj, **kwargs))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ mypy = "^0.910"
 pylint = "^2.11.1"
 pytest-cov = "^3.0.0"
 types-orjson = "^3.6.1"
+autopep8 = "^1.6.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/integration/test_streams.py
+++ b/tests/integration/test_streams.py
@@ -2,13 +2,12 @@ import pytest
 import json_streams
 
 
-
-@pytest.mark.parametrize('kwargs', [{}, {'default':json_streams.encoders.encode_decimal}])
+@pytest.mark.parametrize('dump_kwargs', [{}, {'default': json_streams.encoders.encode_decimal}])
 @pytest.mark.parametrize('outfile', ['tests/data/gen/array.json', 'tests/data/gen/array.jsonl'])
 @pytest.mark.parametrize('infile', ['tests/data/array.json', 'tests/data/array.jsonl'])
-def test_streaming(infile, outfile, kwargs):
+def test_streaming(infile, outfile, dump_kwargs):
     json_streams.dump_to_file(
         json_streams.load_from_file(infile),
         outfile,
-        **kwargs
+        **dump_kwargs
     )

--- a/tests/integration/test_streams.py
+++ b/tests/integration/test_streams.py
@@ -1,10 +1,14 @@
 import pytest
 import json_streams
 
+
+
+@pytest.mark.parametrize('kwargs', [{}, {'default':json_streams.encoders.encode_decimal}])
 @pytest.mark.parametrize('outfile', ['tests/data/gen/array.json', 'tests/data/gen/array.jsonl'])
 @pytest.mark.parametrize('infile', ['tests/data/array.json', 'tests/data/array.jsonl'])
-def test_streaming(infile, outfile):
+def test_streaming(infile, outfile, kwargs):
     json_streams.dump_to_file(
         json_streams.load_from_file(infile),
         outfile,
+        **kwargs
     )

--- a/tests/unit/test_decimal_encoders.py
+++ b/tests/unit/test_decimal_encoders.py
@@ -1,0 +1,10 @@
+from decimal import Decimal
+from json_streams.encoders import encode_decimal
+from json_streams import jsonlib
+
+
+def test_encode_decimal():
+    result = jsonlib.dumps([10.20, '10.20', Decimal('10.20')], default=encode_decimal)
+
+    assert result == jsonlib.dumps([10.20, '10.20', 10.20])
+


### PR DESCRIPTION
Allowing for instance calling  `dump_to_file` with `default=json_streams.encoders.decimal_encoder`